### PR TITLE
Check global feature status

### DIFF
--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -46,7 +46,7 @@ class Unleash implements UnleashInterface
 	{
 		$feature = $this->featureRepository->getFeature($name);
 
-		if ($feature === null) {
+		if ($feature === null || $feature->isDisabled()) {
 			return false;
 		}
 

--- a/tests/UnleashTest.php
+++ b/tests/UnleashTest.php
@@ -184,4 +184,50 @@ class UnleashTest extends TestCase
 
 		$this->assertTrue($unleash->isFeatureEnabled($featureName));
 	}
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::isFeatureEnabled
+	 */
+	public function testIsFeatureEnabledWithDiabledFeature(): void
+	{
+		$featureName = 'random_feature';
+
+		$featureMock = $this->createMock(Feature::class);
+		$featureMock->expects($this->never())->method('getStrategies');
+		$featureMock->expects($this->once())
+			->method('isDisabled')
+			->willReturn(true);
+
+		$featureRepositoryMock = $this->createMock(FeatureRepository::class);
+		$featureRepositoryMock->expects($this->once())
+			->method('getFeature')
+			->with($featureName)
+			->willReturn($featureMock);
+
+		$strategyMock = $this->createMock(StrategyInterface::class);
+		$strategyMock->expects($this->never())->method('isEnabled');
+
+		$strategies = [
+			'userWithId' => $strategyMock,
+		];
+
+		$requestStackMock = $this->createMock(RequestStack::class);
+
+		$tokenStorageMock = $this->createMock(TokenStorageInterface::class);
+		$tokenStorageMock->expects($this->never())->method('getToken');
+
+		$eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
+		$eventDispatcherMock->expects($this->never())->method('dispatch');
+
+		$unleash = new Unleash(
+			$requestStackMock,
+			$tokenStorageMock,
+			$eventDispatcherMock,
+			$featureRepositoryMock,
+			new ArrayIterator($strategies),
+		);
+
+		$this->assertFalse($unleash->isFeatureEnabled($featureName));
+	}
 }


### PR DESCRIPTION
hi,

I found out that a deactivated feature (with default strategy) is handled like an activated. And the default Strategy returns always "true". So the Unleash::isFeatureEnabled() method  is always true.


This PR checks the Feature::$enabled Flag and return "false" if the Feature is disabled in Gitlab.