### PR TITLE
Add Symfony 4.4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PHP from Packagist](https://img.shields.io/packagist/php-v/stogon/unleash-bundle.svg?style=for-the-badge)](https://packagist.org/packages/stogon/unleash-bundle)
 [![License](https://img.shields.io/github/license/Stogon/unleash-bundle.svg?style=for-the-badge)](https://packagist.org/packages/stogon/unleash-bundle)
 
-An [Unleash](https://docs.getunleash.io/) bundle for Symfony applications.
+An [Unleash](https://docs.getunleash.io/) bundle for Symfony 4.4 and 5+  applications.
 
 This provide an easy way to implement **feature flags** using [Gitlab Feature Flags Feature](https://docs.gitlab.com/ee/operations/feature_flags.html).
 
@@ -221,7 +221,7 @@ or
 ```
 $ ./vendor/bin/phpunit
 $ ./vendor/bin/phpstan analyse
-$ ./vendor/bin/php-cs-fixer fix --config=.php_cs.dist
+$ ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php
 ```
 
 ## Contributing

--- a/composer.json
+++ b/composer.json
@@ -5,18 +5,17 @@
     "type": "symfony-bundle",
     "require": {
         "php": "^7.4|^8.0",
-        "symfony/cache": "^5.2",
-        "symfony/config": "^5.2",
-        "symfony/contracts": "^v2.3",
-        "symfony/dependency-injection": "^5.2",
-        "symfony/event-dispatcher": "^5.2",
-        "symfony/http-client": "^5.2",
-        "symfony/http-kernel": "^5.2",
-        "symfony/security-core": "^5.2",
+        "symfony/cache-contracts": "^2.4",
+        "symfony/config": "^4.4|^5.2",
+        "symfony/dependency-injection": "^4.4|^5.2",
+        "symfony/event-dispatcher-contracts": "^1.1|^2.4",
+        "symfony/http-client-contracts": "^2.4",
+        "symfony/http-kernel": "^4.4|^5.2",
+        "symfony/security-core": "^4.4|^5.2",
         "twig/twig": "^2.12|^3.0"
     },
     "require-dev": {
-        "symfony/var-dumper": "^5.2",
+        "symfony/var-dumper": "^4.4|^5.2",
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^0.12.65",
         "friendsofphp/php-cs-fixer": "^3.0"

--- a/config/services.php
+++ b/config/services.php
@@ -36,7 +36,7 @@ return function (ContainerConfigurator $configurator) {
 	$services->set(GradualRolloutRandomStrategy::class)->tag('unleash.strategy', ['activation_name' => 'gradualRolloutRandom']);
 
 	$services->set(FeatureRepository::class)
-		->arg('$httpClient', service(UnleashHttpClient::class))
+		->arg('$httpClient', function_exists('service') ? service(UnleashHttpClient::class) : ref(UnleashHttpClient::class))
 		->arg('$cache', '%unleash.cache.service%')
 		->arg('$ttl', '%unleash.cache.ttl%')
 		->autowire(true)
@@ -51,7 +51,7 @@ return function (ContainerConfigurator $configurator) {
 	$services->alias(UnleashInterface::class, Unleash::class);
 
 	$services->set(UnleashExtension::class)
-		->arg('$unleash', service(UnleashInterface::class))
+		->arg('$unleash', function_exists('service') ? service(UnleashInterface::class) : ref(UnleashInterface::class))
 		->tag('twig.extension')
 	;
 };


### PR DESCRIPTION
 # Features

* Add support for Symfony 4.4 LTS (#5)

# Changes

* Switched from Symfony components to Symfony contracts (`symfony/*-contracts`) for dependencies in `composer.json`