### PR TITLE
Improve error handling

### DIFF
--- a/src/HttpClient/UnleashHttpClient.php
+++ b/src/HttpClient/UnleashHttpClient.php
@@ -21,9 +21,12 @@ class UnleashHttpClient
 
 	public function fetchFeatures(): array
 	{
-		$response = $this->httpClient->request('GET', 'client/features');
-
-		$features = $response->toArray();
+		try {
+			$response = $this->httpClient->request('GET', 'client/features');
+			$features = $response->toArray();
+		} catch (\Throwable $exception) {
+			return [];
+		}
 
 		if (array_key_exists('features', $features)) {
 			return $features['features'];

--- a/tests/HttpClient/UnleashHttpClientTest.php
+++ b/tests/HttpClient/UnleashHttpClientTest.php
@@ -15,6 +15,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 class UnleashHttpClientTest extends TestCase
 {
 	/**
+	 * @covers ::__construct
 	 * @covers ::fetchFeatures
 	 */
 	public function testFetchFeaturesRequestThrows(): void
@@ -39,6 +40,7 @@ class UnleashHttpClientTest extends TestCase
 	}
 
 	/**
+	 * @covers ::__construct
 	 * @covers ::fetchFeatures
 	 */
 	public function testFetchFeaturesToArrayThrows(): void
@@ -68,6 +70,7 @@ class UnleashHttpClientTest extends TestCase
 	}
 
 	/**
+	 * @covers ::__construct
 	 * @covers ::fetchFeatures
 	 */
 	public function testFetchFeaturesArrayFeatureKeyExists(): void
@@ -98,6 +101,7 @@ class UnleashHttpClientTest extends TestCase
 	}
 
 	/**
+	 * @covers ::__construct
 	 * @covers ::fetchFeatures
 	 */
 	public function testFetchFeaturesReturnsDefault(): void

--- a/tests/HttpClient/UnleashHttpClientTest.php
+++ b/tests/HttpClient/UnleashHttpClientTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Stogon\UnleashBundle\Tests\HttpClient;
+
+use PHPUnit\Framework\TestCase;
+use Stogon\UnleashBundle\HttpClient\UnleashHttpClient;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TimeoutExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @coversDefaultClass \Stogon\UnleashBundle\HttpClient\UnleashHttpClient
+ */
+class UnleashHttpClientTest extends TestCase
+{
+	/**
+	 * @covers ::fetchFeatures
+	 */
+	public function testFetchFeaturesRequestThrows(): void
+	{
+		$httpClient = $this->createMock(HttpClientInterface::class);
+		$httpClient
+			->method('request')
+			->willThrowException(
+				$this->createMock(TimeoutExceptionInterface::class)
+			);
+
+		$client = new UnleashHttpClient(
+			$httpClient,
+			'',
+			'',
+			''
+		);
+
+		$result = $client->fetchFeatures();
+
+		self::assertEquals([], $result);
+	}
+
+	/**
+	 * @covers ::fetchFeatures
+	 */
+	public function testFetchFeaturesToArrayThrows(): void
+	{
+		$response = $this->createMock(ResponseInterface::class);
+		$response
+			->method('toArray')->willThrowException(
+				$this->createMock(ClientExceptionInterface::class)
+			);
+
+		$httpClient = $this->createMock(HttpClientInterface::class);
+		$httpClient
+			->method('request')
+			->with('GET', 'client/features')
+			->willReturn($response);
+
+		$client = new UnleashHttpClient(
+			$httpClient,
+			'',
+			'',
+			''
+		);
+
+		$result = $client->fetchFeatures();
+
+		self::assertEquals([], $result);
+	}
+
+	/**
+	 * @covers ::fetchFeatures
+	 */
+	public function testFetchFeaturesArrayFeatureKeyExists(): void
+	{
+		$response = $this->createMock(ResponseInterface::class);
+		$response
+			->method('toArray')
+			->willReturn([
+				'features' => ['foo', 'bar'],
+			]);
+
+		$httpClient = $this->createMock(HttpClientInterface::class);
+		$httpClient
+			->method('request')
+			->with('GET', 'client/features')
+			->willReturn($response);
+
+		$client = new UnleashHttpClient(
+			$httpClient,
+			'',
+			'',
+			''
+		);
+
+		$result = $client->fetchFeatures();
+
+		self::assertEquals(['foo', 'bar'], $result);
+	}
+
+	/**
+	 * @covers ::fetchFeatures
+	 */
+	public function testFetchFeaturesReturnsDefault(): void
+	{
+		$response = $this->createMock(ResponseInterface::class);
+		$response
+			->method('toArray')
+			->willReturn([]);
+
+		$httpClient = $this->createMock(HttpClientInterface::class);
+		$httpClient
+			->method('request')
+			->with('GET', 'client/features')
+			->willReturn($response);
+
+		$client = new UnleashHttpClient(
+			$httpClient,
+			'',
+			'',
+			''
+		);
+
+		$result = $client->fetchFeatures();
+
+		self::assertEquals([], $result);
+	}
+}


### PR DESCRIPTION
In case of a failing request to the unleash server, the whole symfony request fails. Wrapping the request and getting its content into a try catch, makes it more robust.

Should additionally some logging be added?