### PR TITLE
Add explicit token whether $token equals null

### DIFF
--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -70,7 +70,7 @@ class Unleash implements UnleashInterface
 		$token = $this->tokenStorage->getToken();
 		$user = null;
 
-		if (!method_exists($token, 'isAuthenticated')) {
+		if ($token === null || !method_exists($token, 'isAuthenticated')) {
 			$authenticated = $token !== null;
 		} else {
 			$authenticated = $token !== null && $token->isAuthenticated();


### PR DESCRIPTION
In PHP 8, the signature of method_exists does not allow for null values as the first argument. Because $token is not verified, this will crash when calling isFeatureEnabled when the user is not signed in (the registration page in our case).