### PR TITLE
v0.7.2

### DIFF
--- a/src/DependencyInjection/UnleashExtension.php
+++ b/src/DependencyInjection/UnleashExtension.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class UnleashExtension extends Extension implements PrependExtensionInterface
 {
-	public function load(array $configs, ContainerBuilder $container)
+	public function load(array $configs, ContainerBuilder $container): void
 	{
 		$loader = new PhpFileLoader(
 			$container,
@@ -28,7 +28,7 @@ class UnleashExtension extends Extension implements PrependExtensionInterface
 		$definition->replaceArgument('$cache', new Reference($container->getParameter('unleash.cache.service')));
 	}
 
-	public function prepend(ContainerBuilder $container)
+	public function prepend(ContainerBuilder $container): void
 	{
 		$configuration = new Configuration();
 

--- a/src/Helper/ValueNormalizer.php
+++ b/src/Helper/ValueNormalizer.php
@@ -17,6 +17,11 @@ class ValueNormalizer
 			return $min - 1;
 		}
 
+		if (PHP_VERSION_ID >= 80100) {
+			// Use native murmur3a hash if supported
+			return ((int) base_convert(hash('murmur3a', "{$id}:{$groupId}"), 32, 10) % $normalizer) + $min;
+		}
+
 		return (Murmur::hash3_int("{$id}:{$groupId}") % $normalizer) + $min;
 	}
 }


### PR DESCRIPTION
# Changes

* [8313807bd778fd699c49432566e9399003ef4c7c] Use native `hash('murmur3a', ...)` function on PHP >= 8.1 

# Fixes

* [ab0fb6b565d180b4d367882ece4f4adca7c52c77] Add return types to `UnleashExtension` functions