### PR TITLE
Remove static $defaultName in commands

### DIFF
--- a/src/Command/FetchFeaturesCommand.php
+++ b/src/Command/FetchFeaturesCommand.php
@@ -12,15 +12,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[\Symfony\Component\Console\Attribute\AsCommand('unleash:features:fetch', 'Fetch Unleash features from remote and store them in the cache for later usage.')]
 class FetchFeaturesCommand extends Command
 {
-	protected static $defaultName = 'unleash:features:fetch';
-
 	private FeatureRepository $featureRepository;
 
 	public function __construct(FeatureRepository $featureRepository)
 	{
 		$this->featureRepository = $featureRepository;
 
-		parent::__construct();
+		parent::__construct('unleash:features:fetch');
 	}
 
 	protected function configure(): void

--- a/src/Command/ListFeaturesCommand.php
+++ b/src/Command/ListFeaturesCommand.php
@@ -13,15 +13,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[\Symfony\Component\Console\Attribute\AsCommand('unleash:features:list', 'List available Unleash features from remote.')]
 class ListFeaturesCommand extends Command
 {
-	protected static $defaultName = 'unleash:features:list';
-
 	private FeatureRepository $featureRepository;
 
 	public function __construct(FeatureRepository $featureRepository)
 	{
 		$this->featureRepository = $featureRepository;
 
-		parent::__construct();
+		parent::__construct('unleash:features:list');
 	}
 
 	protected function configure(): void


### PR DESCRIPTION
The `$defaultName` property is deprecated since Symfony 6.1 and will be removed in Symfony 7.

Instead, we can use the `AsCommand` attribute for Symfony 6+, and provide the command name to the parent constructor call for Symfony 4/5