### PR TITLE
v1.0.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,17 +11,17 @@ jobs:
       fail-fast: false
       matrix:
         php-versions:
-          - '7.4'
-          - '8.0'
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
+          - '8.5'
         dependencies:
           - "lowest"
           - "highest"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
@@ -42,19 +42,19 @@ jobs:
       run: echo "DIR=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache composer dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.DIR }}
         key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
         restore-keys: ${{ runner.os }}-composer-
 
-    - uses: "ramsey/composer-install@v2"
+    - uses: "ramsey/composer-install@v3"
       name: Install Composer dependencies
       with:
         dependency-versions: "${{ matrix.dependencies }}"
 
     - name: Run PHPUnit Tests
-      uses: php-actions/phpunit@v3
+      uses: php-actions/phpunit@v4
       env:
         XDEBUG_MODE: coverage
       with:
@@ -67,7 +67,7 @@ jobs:
         args: --coverage-text
 
     - name: Upload to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,7 +58,7 @@ jobs:
       env:
         XDEBUG_MODE: coverage
       with:
-        version: 9.6
+        version: 10.5
         php_version: "${{ matrix.php-versions }}"
         bootstrap: "vendor/autoload.php"
         configuration: "./phpunit.xml"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/Stogon/unleash-bundle.svg?style=for-the-badge)](https://packagist.org/packages/stogon/unleash-bundle)
 [![codecov](https://img.shields.io/codecov/c/github/Stogon/unleash-bundle/master?token=NI6FM0TCMS&style=for-the-badge)](https://codecov.io/gh/Stogon/unleash-bundle)
 
-An [Unleash](https://docs.getunleash.io/) bundle for Symfony 5.4+, 6.4+ and 7.0+ applications.
+An [Unleash](https://docs.getunleash.io/) bundle for Symfony 6.4+ and 7.4+ applications.
 
 This provide an easy way to implement **feature flags** using [Gitlab Feature Flags Feature](https://docs.gitlab.com/ee/operations/feature_flags.html).
 
@@ -66,7 +66,7 @@ namespace App\Controller;
 use Stogon\UnleashBundle\UnleashInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class HomeController extends AbstractController
 {
@@ -152,7 +152,7 @@ use Stogon\UnleashBundle\Strategy\StrategyInterface;
 
 class MyCustomStrategy implements StrategyInterface
 {
-    public function isEnabled(array $parameters = [], array $context = [], ...$args): bool
+    public function isEnabled(array $parameters = [], array $context = [], mixed ...$args): bool
     {
         // TODO: Implement your custom logic here.
 

--- a/composer.json
+++ b/composer.json
@@ -5,24 +5,24 @@
 	"readme": "./README.md",
     "type": "symfony-bundle",
     "require": {
-        "php": "^7.4|^8.0",
-        "lastguest/murmurhash": "^2.1",
-        "symfony/cache-contracts": "^2.4|^3.0",
-        "symfony/config": "^5.4|^6.4|^7.0",
-        "symfony/console": "^5.4|^6.4|^7.0",
-        "symfony/dependency-injection": "^5.4|^6.4|^7.0",
-        "symfony/event-dispatcher-contracts": "^2.4|^3.0",
-        "symfony/http-client-contracts": "^2.4|^3.0",
-        "symfony/http-kernel": "^5.4.20|^6.4|^7.0",
-        "symfony/security-core": "^5.4|^6.4|^7.0",
-        "twig/twig": "^2.12|>=3.11.2"
+        "php": "^8.1",
+        "symfony/cache-contracts": "^3.0",
+        "symfony/config": "^6.4|^7.4",
+        "symfony/console": "^6.4|^7.4",
+        "symfony/dependency-injection": "^6.4|^7.4",
+        "symfony/event-dispatcher-contracts": "^3.0",
+        "symfony/http-client-contracts": "^3.0",
+        "symfony/http-kernel": "^6.4|^7.4",
+        "symfony/security-core": "^6.4|^7.4",
+        "twig/twig": "^3.15.0"
     },
     "require-dev": {
-        "symfony/var-dumper": "^5.4|^6.4|^7.0",
-        "phpunit/phpunit": "^9.6",
-        "phpstan/phpstan": "^1.12.0",
-        "psr/log": "^1|^2|^3",
-        "friendsofphp/php-cs-fixer": "^3.64"
+        "friendsofphp/php-cs-fixer": "^3.91",
+        "phpstan/phpstan": "^2.0.0",
+        "phpunit/phpunit": "^10.5",
+        "psr/log": "^2|^3",
+        "rector/rector": "^2.0",
+        "symfony/var-dumper": "^6.4|^7.4"
     },
     "scripts": {
         "cs-fixer": "php-cs-fixer fix --config=.php-cs-fixer.dist.php --diff --dry-run",

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.91",
-        "phpstan/phpstan": "^2.0.0",
-        "phpunit/phpunit": "^10.5",
+        "phpstan/phpstan": "^2.1.30",
+        "phpunit/phpunit": "^10.5.60",
         "psr/log": "^2|^3",
         "rector/rector": "^2.0",
         "symfony/var-dumper": "^6.4|^7.4"

--- a/config/services.php
+++ b/config/services.php
@@ -18,7 +18,7 @@ use Stogon\UnleashBundle\Twig\UnleashExtension;
 use Stogon\UnleashBundle\Unleash;
 use Stogon\UnleashBundle\UnleashInterface;
 
-return function (ContainerConfigurator $configurator) {
+return function (ContainerConfigurator $configurator): void {
 	$services = $configurator->services();
 
 	$services->instanceof(StrategyInterface::class)->tag('unleash.strategy');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,5 +4,3 @@ parameters:
         - src
         - tests
     reportUnmatchedIgnoredErrors: false
-    ignoreErrors:
-        - '#Call to an undefined method Symfony\\Component\\Security\\Core\\User\\UserInterface::getUsername\(\)\.#'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,26 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         cacheResultFile=".phpunit.cache/test-results"
-         executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory suffix="Test.php">tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="true">
+  <testsuites>
+    <testsuite name="default">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
+  <coverage />
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+	->withPaths([
+		__DIR__.'/config',
+		__DIR__.'/src',
+		__DIR__.'/tests',
+	])
+	// uncomment to reach your current PHP version
+	->withPhpSets(php81: true)
+	->withAttributesSets(symfony: true, phpunit: true)
+	->withTypeCoverageLevel(0);

--- a/src/Cache/FeatureCacheWarmer.php
+++ b/src/Cache/FeatureCacheWarmer.php
@@ -7,11 +7,8 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
 class FeatureCacheWarmer implements CacheWarmerInterface
 {
-	private FeatureRepository $featureRepository;
-
-	public function __construct(FeatureRepository $featureRepository)
+	public function __construct(private readonly FeatureRepository $featureRepository)
 	{
-		$this->featureRepository = $featureRepository;
 	}
 
 	public function warmUp(string $cacheDir, ?string $buildDir = null): array

--- a/src/Command/FetchFeaturesCommand.php
+++ b/src/Command/FetchFeaturesCommand.php
@@ -12,12 +12,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand('unleash:features:fetch', 'Fetch Unleash features from remote and store them in the cache for later usage.')]
 class FetchFeaturesCommand extends Command
 {
-	private FeatureRepository $featureRepository;
-
-	public function __construct(FeatureRepository $featureRepository)
+	public function __construct(private readonly FeatureRepository $featureRepository)
 	{
-		$this->featureRepository = $featureRepository;
-
 		parent::__construct('unleash:features:fetch');
 	}
 

--- a/src/Command/ListFeaturesCommand.php
+++ b/src/Command/ListFeaturesCommand.php
@@ -13,12 +13,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[AsCommand('unleash:features:list', 'List available Unleash features from remote.')]
 class ListFeaturesCommand extends Command
 {
-	private FeatureRepository $featureRepository;
-
-	public function __construct(FeatureRepository $featureRepository)
+	public function __construct(private readonly FeatureRepository $featureRepository)
 	{
-		$this->featureRepository = $featureRepository;
-
 		parent::__construct('unleash:features:list');
 	}
 
@@ -44,9 +40,7 @@ class ListFeaturesCommand extends Command
 		$io->table([
 			'Name', 'Description', 'Stategies',
 		], array_map(function (FeatureInterface $feature): array {
-			$strategiesName = array_map(function (array $strategy): string {
-				return $strategy['name'];
-			}, $feature->getStrategies());
+			$strategiesName = array_map(fn (array $strategy): string => $strategy['name'], $feature->getStrategies());
 
 			return [
 				$feature->getName(),

--- a/src/Event/UnleashContextEvent.php
+++ b/src/Event/UnleashContextEvent.php
@@ -6,11 +6,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class UnleashContextEvent extends Event
 {
-	private array $payload;
-
-	public function __construct(array $payload = [])
+	public function __construct(private array $payload = [])
 	{
-		$this->payload = $payload;
 	}
 
 	public function getPayload(): array

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -4,17 +4,12 @@ namespace Stogon\UnleashBundle;
 
 class Feature implements FeatureInterface
 {
-	private string $name;
-	private string $description;
-	private bool $enabled = false;
-	protected array $stategies = [];
-
-	public function __construct(string $name, string $description, bool $enabled, array $strategies = [])
-	{
-		$this->name = $name;
-		$this->description = $description;
-		$this->enabled = $enabled;
-		$this->stategies = $strategies;
+	public function __construct(
+		private readonly string $name,
+		private readonly string $description,
+		private readonly bool $enabled,
+		protected array $stategies = []
+	) {
 	}
 
 	public function getName(): string

--- a/src/Helper/ValueNormalizer.php
+++ b/src/Helper/ValueNormalizer.php
@@ -2,8 +2,6 @@
 
 namespace Stogon\UnleashBundle\Helper;
 
-use lastguest\Murmur;
-
 class ValueNormalizer
 {
 	/**
@@ -17,11 +15,6 @@ class ValueNormalizer
 			return $min - 1;
 		}
 
-		if (PHP_VERSION_ID >= 80100) {
-			// Use native murmur3a hash if supported
-			return ((int) base_convert((string) hash('murmur3a', "{$id}:{$groupId}"), 32, 10) % $normalizer) + $min;
-		}
-
-		return (Murmur::hash3_int("{$id}:{$groupId}") % $normalizer) + $min;
+		return ((int) base_convert((string) hash('murmur3a', "{$id}:{$groupId}"), 32, 10) % $normalizer) + $min;
 	}
 }

--- a/src/HttpClient/UnleashHttpClient.php
+++ b/src/HttpClient/UnleashHttpClient.php
@@ -11,17 +11,12 @@ class UnleashHttpClient implements LoggerAwareInterface
 {
 	use LoggerAwareTrait;
 
-	private HttpClientInterface $httpClient;
-	protected string $apiUrl;
-	protected string $instanceId;
-	protected string $environment;
-
-	public function __construct(HttpClientInterface $unleashClient, string $apiUrl, string $instanceId, string $environment)
-	{
-		$this->httpClient = $unleashClient;
-		$this->apiUrl = $apiUrl;
-		$this->instanceId = $instanceId;
-		$this->environment = $environment;
+	public function __construct(
+		private readonly HttpClientInterface $httpClient,
+		protected readonly string $apiUrl,
+		protected readonly string $instanceId,
+		protected readonly string $environment
+	) {
 		$this->logger = new NullLogger();
 	}
 

--- a/src/Repository/FeatureRepository.php
+++ b/src/Repository/FeatureRepository.php
@@ -9,15 +9,11 @@ use Symfony\Contracts\Cache\ItemInterface;
 
 class FeatureRepository
 {
-	protected UnleashHttpClient $client;
-	protected CacheInterface $cache;
-	protected int $ttl;
-
-	public function __construct(UnleashHttpClient $httpClient, CacheInterface $cache, int $ttl)
-	{
-		$this->client = $httpClient;
-		$this->cache = $cache;
-		$this->ttl = $ttl;
+	public function __construct(
+		protected readonly UnleashHttpClient $client,
+		protected readonly CacheInterface $cache,
+		protected int $ttl
+	) {
 	}
 
 	/**
@@ -30,14 +26,12 @@ class FeatureRepository
 
 			$item->expiresAfter($this->ttl);
 
-			return array_map(function (array $feature): Feature {
-				return new Feature(
-					$feature['name'],
-					$feature['description'],
-					$feature['enabled'],
-					$feature['strategies']
-				);
-			}, $features);
+			return array_map(fn (array $feature): Feature => new Feature(
+				$feature['name'],
+				$feature['description'],
+				$feature['enabled'],
+				$feature['strategies']
+			), $features);
 		});
 	}
 

--- a/src/Strategy/DefaultStrategy.php
+++ b/src/Strategy/DefaultStrategy.php
@@ -4,7 +4,7 @@ namespace Stogon\UnleashBundle\Strategy;
 
 class DefaultStrategy implements StrategyInterface
 {
-	public function isEnabled(array $parameters = [], array $context = [], ...$args): bool
+	public function isEnabled(array $parameters = [], array $context = [], mixed ...$args): bool
 	{
 		return true;
 	}

--- a/src/Strategy/GradualRolloutRandomStrategy.php
+++ b/src/Strategy/GradualRolloutRandomStrategy.php
@@ -6,7 +6,7 @@ use Stogon\UnleashBundle\Helper\ValueNormalizer;
 
 class GradualRolloutRandomStrategy implements StrategyInterface
 {
-	public function isEnabled(array $parameters = [], array $context = [], ...$args): bool
+	public function isEnabled(array $parameters = [], array $context = [], mixed ...$args): bool
 	{
 		$percentage = intval($parameters['percentage'] ?? 0);
 		$groupId = trim($parameters['groupId'] ?? '');

--- a/src/Strategy/GradualRolloutSessionIdStrategy.php
+++ b/src/Strategy/GradualRolloutSessionIdStrategy.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class GradualRolloutSessionIdStrategy implements StrategyInterface
 {
-	public function isEnabled(array $parameters = [], array $context = [], ...$args): bool
+	public function isEnabled(array $parameters = [], array $context = [], mixed ...$args): bool
 	{
 		$percentage = intval($parameters['percentage'] ?? 0);
 		$groupId = trim($parameters['groupId'] ?? '');

--- a/src/Strategy/GradualRolloutUserIdStrategy.php
+++ b/src/Strategy/GradualRolloutUserIdStrategy.php
@@ -7,7 +7,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class GradualRolloutUserIdStrategy implements StrategyInterface
 {
-	public function isEnabled(array $parameters = [], array $context = [], ...$args): bool
+	public function isEnabled(array $parameters = [], array $context = [], mixed ...$args): bool
 	{
 		$percentage = intval($parameters['percentage'] ?? 0);
 		$groupId = trim($parameters['groupId'] ?? '');
@@ -25,19 +25,13 @@ class GradualRolloutUserIdStrategy implements StrategyInterface
 	protected function getUserId(array $context): ?string
 	{
 		if (array_key_exists('user', $context) && $context['user'] !== null) {
-			/** @var UserInterface */
 			$currentUser = $context['user'];
-
-			if (method_exists($currentUser, 'getId')) {
-				return $currentUser->getId();
+			if ($currentUser instanceof UserInterface) {
+				return $currentUser->getUserIdentifier();
 			}
 
-			if ($currentUser instanceof UserInterface) {
-				if (method_exists($currentUser, 'getUserIdentifier')) {
-					return $currentUser->getUserIdentifier();
-				}
-
-				return $currentUser->getUsername();
+			if (is_object($currentUser) && method_exists($currentUser, 'getId')) {
+				return $currentUser->getId();
 			}
 		}
 

--- a/src/Strategy/StrategyInterface.php
+++ b/src/Strategy/StrategyInterface.php
@@ -4,5 +4,5 @@ namespace Stogon\UnleashBundle\Strategy;
 
 interface StrategyInterface
 {
-	public function isEnabled(array $parameters = [], array $context = [], ...$args): bool;
+	public function isEnabled(array $parameters = [], array $context = [], mixed ...$args): bool;
 }

--- a/src/Strategy/UserWithIdStrategy.php
+++ b/src/Strategy/UserWithIdStrategy.php
@@ -7,34 +7,27 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class UserWithIdStrategy implements StrategyInterface
 {
-	public function isEnabled(array $parameters = [], array $context = [], ...$args): bool
+	public function isEnabled(array $parameters = [], array $context = [], mixed ...$args): bool
 	{
 		$userIds = $parameters['userIds'] ?? [];
 
-		$ids = array_map('trim', explode(',', $userIds));
+		$ids = array_map('trim', explode(',', (string) $userIds));
 
 		if ($context['user']) {
-			/** @var UserInterface */
 			$currentUser = $context['user'];
 
-			if (method_exists($currentUser, 'getId') && in_array($currentUser->getId(), $ids, false)) {
-				return true;
-			}
-
-			if (!$currentUser instanceof UserInterface) {
-				return false;
-			}
-
-			if (method_exists($currentUser, 'getUserIdentifier')) {
+			if ($currentUser instanceof UserInterface) {
 				return in_array($currentUser->getUserIdentifier(), $ids, false);
 			}
 
-			return in_array($currentUser->getUsername(), $ids, false);
+			if (is_object($currentUser) && method_exists($currentUser, 'getId') && in_array($currentUser->getId(), $ids, false)) {
+				return true;
+			}
 		}
 
-		/** @var Request */
-		$request = $context['request'];
+		/** @var Request|null */
+		$request = $context['request'] ?? null;
 
-		return in_array($request->getUser(), $ids, false);
+		return in_array($request?->getUser(), $ids, false);
 	}
 }

--- a/src/Twig/UnleashExtension.php
+++ b/src/Twig/UnleashExtension.php
@@ -8,18 +8,15 @@ use Twig\TwigFunction;
 
 class UnleashExtension extends AbstractExtension
 {
-	protected UnleashInterface $unleash;
-
-	public function __construct(UnleashInterface $unleash)
+	public function __construct(protected readonly UnleashInterface $unleash)
 	{
-		$this->unleash = $unleash;
 	}
 
 	public function getFunctions(): array
 	{
 		return [
-			new TwigFunction('is_feature_enabled', [$this, 'isFeatureEnabled']),
-			new TwigFunction('is_feature_disabled', [$this, 'isFeatureDisabled']),
+			new TwigFunction('is_feature_enabled', $this->isFeatureEnabled(...)),
+			new TwigFunction('is_feature_disabled', $this->isFeatureDisabled(...)),
 		];
 	}
 

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -13,27 +13,19 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class Unleash implements UnleashInterface
 {
-	protected RequestStack $requestStack;
-	protected TokenStorageInterface $tokenStorage;
-	protected EventDispatcherInterface $eventDispatcher;
-	protected FeatureRepository $featureRepository;
-	/** @var iterable<StrategyInterface> */
-	protected iterable $strategiesMapping;
 	protected LoggerInterface $logger;
 
+	/**
+	 * @param iterable<string, StrategyInterface> $strategiesMapping
+	 */
 	public function __construct(
-		RequestStack $requestStack,
-		TokenStorageInterface $tokenStorage,
-		EventDispatcherInterface $eventDispatcher,
-		FeatureRepository $featureRepository,
-		iterable $strategiesMapping,
+		protected readonly RequestStack $requestStack,
+		protected readonly TokenStorageInterface $tokenStorage,
+		protected readonly EventDispatcherInterface $eventDispatcher,
+		protected readonly FeatureRepository $featureRepository,
+		protected readonly iterable $strategiesMapping,
 		?LoggerInterface $logger = null
 	) {
-		$this->requestStack = $requestStack;
-		$this->tokenStorage = $tokenStorage;
-		$this->eventDispatcher = $eventDispatcher;
-		$this->featureRepository = $featureRepository;
-		$this->strategiesMapping = $strategiesMapping;
 		$this->logger = $logger ?: new NullLogger();
 	}
 
@@ -66,6 +58,7 @@ class Unleash implements UnleashInterface
 			'name' => $name,
 		]);
 
+		/** @var array<string, StrategyInterface> */
 		$strategies = iterator_to_array($this->strategiesMapping);
 		$token = $this->tokenStorage->getToken();
 		$user = null;
@@ -99,6 +92,7 @@ class Unleash implements UnleashInterface
 
 			$strategy = $strategies[$strategyName];
 
+			// @phpstan-ignore-next-line
 			if (!$strategy instanceof StrategyInterface) {
 				throw new \Exception(sprintf('%s does not implement %s interface.', $strategyName, StrategyInterface::class));
 			}

--- a/tests/Cache/FeatureCacheWarmerTest.php
+++ b/tests/Cache/FeatureCacheWarmerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Stogon\UnleashBundle\Tests\Cache;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Stogon\UnleashBundle\Cache\FeatureCacheWarmer;
+use Stogon\UnleashBundle\Repository\FeatureRepository;
+
+#[CoversClass(FeatureCacheWarmer::class)]
+class FeatureCacheWarmerTest extends TestCase
+{
+	/**
+	 * @param array{featureRepository?: FeatureRepository} $args
+	 */
+	protected function buildInstance(array $args = []): FeatureCacheWarmer
+	{
+		return new FeatureCacheWarmer(...[
+			'featureRepository' => $this->createMock(FeatureRepository::class),
+			...$args,
+		]);
+	}
+
+	public function testWarmUp(): void
+	{
+		$featureRepository = $this->createMock(FeatureRepository::class);
+		$featureRepository->expects($this->once())
+			->method('getFeatures');
+
+		$warmer = $this->buildInstance([
+			'featureRepository' => $featureRepository,
+		]);
+
+		$files = $warmer->warmUp(__DIR__, __DIR__);
+
+		// There should be no file to preload
+		$this->assertCount(0, $files);
+	}
+
+	public function testIsOptional(): void
+	{
+		$warmer = $this->buildInstance();
+
+		$this->assertTrue($warmer->isOptional());
+	}
+}

--- a/tests/Event/UnleashContextEventTest.php
+++ b/tests/Event/UnleashContextEventTest.php
@@ -5,15 +5,9 @@ namespace Stogon\UnleashBundle\Tests\Event;
 use PHPUnit\Framework\TestCase;
 use Stogon\UnleashBundle\Event\UnleashContextEvent;
 
-/**
- * @coversDefaultClass \Stogon\UnleashBundle\Event\UnleashContextEvent
- */
+#[\PHPUnit\Framework\Attributes\CoversClass(UnleashContextEvent::class)]
 class UnleashContextEventTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::getPayload
-	 */
 	public function testConstruct(): void
 	{
 		$event = new UnleashContextEvent([
@@ -24,11 +18,6 @@ class UnleashContextEventTest extends TestCase
 		$this->assertContains('random_value', $event->getPayload());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::getPayload
-	 * @covers ::setPayload
-	 */
 	public function testSetPayload(): void
 	{
 		$event = new UnleashContextEvent([

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -6,19 +6,9 @@ use PHPUnit\Framework\TestCase;
 use Stogon\UnleashBundle\Feature;
 use Stogon\UnleashBundle\Strategy\StrategyInterface;
 
-/**
- * @coversDefaultClass \Stogon\UnleashBundle\Feature
- */
+#[\PHPUnit\Framework\Attributes\CoversClass(Feature::class)]
 class FeatureTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::getName
-	 * @covers ::getDescription
-	 * @covers ::isEnabled
-	 * @covers ::isDisabled
-	 * @covers ::getStrategies
-	 */
 	public function testConstruct(): void
 	{
 		$strategies = [

--- a/tests/Helper/ValueNormalizerTest.php
+++ b/tests/Helper/ValueNormalizerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Stogon\UnleashBundle\Tests\Helper;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Stogon\UnleashBundle\Helper\ValueNormalizer;
+
+#[CoversClass(ValueNormalizer::class)]
+class ValueNormalizerTest extends TestCase
+{
+	public static function valueProvider(): \Iterator
+	{
+		yield 'with numeric ID, no group' => [
+			'1', // id
+			'', // groupId
+			100, // normalizer
+			1, // min
+			7, // expected
+		];
+		yield 'with UUID, no group' => [
+			'801a6d2d-6467-49bd-81e8-263677daa5f1', // id
+			'', // groupId
+			100, // normalizer
+			1, // min
+			31, // expected
+		];
+		yield 'with random chars, no group' => [
+			'.+"*ç%&/()=', // id
+			'', // groupId
+			100, // normalizer
+			1, // min
+			30, // expected
+		];
+
+		yield 'with numeric ID, defined group' => [
+			'1', // id
+			'admin', // groupId
+			100, // normalizer
+			1, // min
+			13, // expected
+		];
+		yield 'with UUID, defined group' => [
+			'801a6d2d-6467-49bd-81e8-263677daa5f1', // id
+			'admin', // groupId
+			100, // normalizer
+			1, // min
+			28, // expected
+		];
+		yield 'with random chars, defined group' => [
+			'.+"*ç%&/()=', // id
+			'admin', // groupId
+			100, // normalizer
+			1, // min
+			31, // expected
+		];
+	}
+
+	#[DataProvider('valueProvider')]
+	public function testBuild(string $id, string $groupId, int $normalizer, int $min, int $expected): void
+	{
+		$value = ValueNormalizer::build($id, $groupId, $normalizer, $min);
+
+		$this->assertGreaterThan($min, $value);
+		$this->assertLessThan($normalizer, $value);
+		$this->assertSame($expected, $value);
+	}
+}

--- a/tests/HttpClient/UnleashHttpClientTest.php
+++ b/tests/HttpClient/UnleashHttpClientTest.php
@@ -9,15 +9,9 @@ use Symfony\Contracts\HttpClient\Exception\TimeoutExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-/**
- * @coversDefaultClass \Stogon\UnleashBundle\HttpClient\UnleashHttpClient
- */
+#[\PHPUnit\Framework\Attributes\CoversClass(UnleashHttpClient::class)]
 class UnleashHttpClientTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::fetchFeatures
-	 */
 	public function testFetchFeaturesRequestThrows(): void
 	{
 		$httpClient = $this->createMock(HttpClientInterface::class);
@@ -39,10 +33,6 @@ class UnleashHttpClientTest extends TestCase
 		self::assertEquals([], $result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::fetchFeatures
-	 */
 	public function testFetchFeaturesToArrayThrows(): void
 	{
 		$response = $this->createMock(ResponseInterface::class);
@@ -69,10 +59,6 @@ class UnleashHttpClientTest extends TestCase
 		self::assertEquals([], $result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::fetchFeatures
-	 */
 	public function testFetchFeaturesArrayFeatureKeyExists(): void
 	{
 		$response = $this->createMock(ResponseInterface::class);
@@ -100,10 +86,6 @@ class UnleashHttpClientTest extends TestCase
 		self::assertEquals(['foo', 'bar'], $result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::fetchFeatures
-	 */
 	public function testFetchFeaturesReturnsDefault(): void
 	{
 		$response = $this->createMock(ResponseInterface::class);

--- a/tests/Strategy/Fixtures/SimpleUser.php
+++ b/tests/Strategy/Fixtures/SimpleUser.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Stogon\UnleashBundle\Tests\Strategy\Fixtures;
+
+class SimpleUser
+{
+	public function __construct(private readonly int|string $id)
+	{
+	}
+
+	public function getId(): int|string
+	{
+		return $this->id;
+	}
+}

--- a/tests/Strategy/Fixtures/User.php
+++ b/tests/Strategy/Fixtures/User.php
@@ -1,18 +1,13 @@
 <?php
 
-namespace Stogon\UnleashBundle\Tests\Strategy;
+namespace Stogon\UnleashBundle\Tests\Strategy\Fixtures;
 
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class User implements UserInterface
 {
-	private $id;
-	private string $username;
-
-	public function __construct($id, string $username)
+	public function __construct(private $id, private readonly string $username)
 	{
-		$this->id = $id;
-		$this->username = $username;
 	}
 
 	public function getId()

--- a/tests/Strategy/UserWithIdStrategyTest.php
+++ b/tests/Strategy/UserWithIdStrategyTest.php
@@ -4,25 +4,17 @@ namespace Stogon\UnleashBundle\Tests\Strategy;
 
 use PHPUnit\Framework\TestCase;
 use Stogon\UnleashBundle\Strategy\UserWithIdStrategy;
+use Stogon\UnleashBundle\Tests\Strategy\Fixtures\SimpleUser;
+use Stogon\UnleashBundle\Tests\Strategy\Fixtures\User;
 
-/**
- * @coversDefaultClass \Stogon\UnleashBundle\Strategy\UserWithIdStrategy
- */
+#[\PHPUnit\Framework\Attributes\CoversClass(UserWithIdStrategy::class)]
 class UserWithIdStrategyTest extends TestCase
 {
-	/**
-	 * @dataProvider usernameProvider
-	 *
-	 * @covers ::isEnabled
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('usernameProvider')]
 	public function testIsEnabledWithUserIdentifier(array $parameters, string $username, bool $expected): void
 	{
 		$userMock = $this->createMock(User::class);
-		if (method_exists(User::class, 'getUserIdentifier')) {
-			$userMock->method('getUserIdentifier')->willReturn($username);
-		} else {
-			$userMock->method('getUsername')->willReturn($username);
-		}
+		$userMock->method('getUserIdentifier')->willReturn($username);
 
 		$context = [
 			'user' => $userMock,
@@ -60,14 +52,10 @@ class UserWithIdStrategyTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider idProvider
-	 *
-	 * @covers ::isEnabled
-	 */
-	public function testIsEnabledWithId(array $parameters, $id, bool $expected): void
+	#[\PHPUnit\Framework\Attributes\DataProvider('idProvider')]
+	public function testIsEnabledWithId(array $parameters, int|string $id, bool $expected): void
 	{
-		$userMock = $this->createMock(User::class);
+		$userMock = $this->createMock(SimpleUser::class);
 		$userMock->method('getId')->willReturn($id);
 
 		$context = [
@@ -82,21 +70,21 @@ class UserWithIdStrategyTest extends TestCase
 	public static function idProvider(): array
 	{
 		return [
-			[
+			'with string identifier' => [
 				[
 					'userIds' => '1,2,3',
 				],
 				'1',
 				true,
 			],
-			[
+			'with numeric identifier' => [
 				[
 					'userIds' => '1,2,3',
 				],
 				2,
 				true,
 			],
-			[
+			'with unknown identifier' => [
 				[
 					'userIds' => '1,2,3',
 				],

--- a/tests/Twig/UnleashExtensionTest.php
+++ b/tests/Twig/UnleashExtensionTest.php
@@ -6,9 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Stogon\UnleashBundle\Twig\UnleashExtension;
 use Stogon\UnleashBundle\UnleashInterface;
 
-/**
- * @coversDefaultClass \Stogon\UnleashBundle\Twig\UnleashExtension
- */
+#[\PHPUnit\Framework\Attributes\CoversClass(UnleashExtension::class)]
 class UnleashExtensionTest extends TestCase
 {
 	protected const FEATURES = [
@@ -16,10 +14,6 @@ class UnleashExtensionTest extends TestCase
 		'beta_feature' => false,
 	];
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::isFeatureEnabled
-	 */
 	public function testIsFeatureEnabled(): void
 	{
 		$unleashMock = $this->createMock(UnleashInterface::class);
@@ -35,10 +29,6 @@ class UnleashExtensionTest extends TestCase
 		$this->assertTrue($result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::isFeatureEnabled
-	 */
 	public function testIsFeatureEnabledWithFallback(): void
 	{
 		$unleashMock = $this->createMock(UnleashInterface::class);
@@ -54,10 +44,6 @@ class UnleashExtensionTest extends TestCase
 		$this->assertTrue($result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::isFeatureDisabled
-	 */
 	public function testIsFeatureDisabled(): void
 	{
 		$unleashMock = $this->createMock(UnleashInterface::class);
@@ -73,10 +59,6 @@ class UnleashExtensionTest extends TestCase
 		$this->assertTrue($result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::isFeatureDisabled
-	 */
 	public function testIsFeatureDisabledWithFallback(): void
 	{
 		$unleashMock = $this->createMock(UnleashInterface::class);

--- a/tests/UnleashTest.php
+++ b/tests/UnleashTest.php
@@ -16,15 +16,10 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-/**
- * @coversDefaultClass \Stogon\UnleashBundle\Unleash
- */
+#[\PHPUnit\Framework\Attributes\CoversClass(Unleash::class)]
+#[\PHPUnit\Framework\Attributes\CoversClass(UnleashContextEvent::class)]
 class UnleashTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::getFeatures
-	 */
 	public function testGetFeatures(): void
 	{
 		$featureMock1 = $this->createMock(FeatureInterface::class);
@@ -50,10 +45,6 @@ class UnleashTest extends TestCase
 		$this->assertContainsOnlyInstancesOf(FeatureInterface::class, $features);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::getFeature
-	 */
 	public function testGetFeature(): void
 	{
 		$name = 'super_feature';
@@ -79,10 +70,6 @@ class UnleashTest extends TestCase
 		$this->assertSame($featureMock, $feature);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::getFeature
-	 */
 	public function testGetFeatureWithMissingFeature(): void
 	{
 		$name = 'random_feature';
@@ -106,12 +93,6 @@ class UnleashTest extends TestCase
 		$this->assertNull($feature);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::isFeatureEnabled
-	 * @covers \Stogon\UnleashBundle\Event\UnleashContextEvent::__construct
-	 * @covers \Stogon\UnleashBundle\Event\UnleashContextEvent::getPayload
-	 */
 	public function testIsFeatureEnabledWithoutDefaultValueWithUnauthenticated(): void
 	{
 		$featureName = 'random_feature';
@@ -174,12 +155,6 @@ class UnleashTest extends TestCase
 		$this->assertTrue($unleash->isFeatureEnabled($featureName));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::isFeatureEnabled
-	 * @covers \Stogon\UnleashBundle\Event\UnleashContextEvent::__construct
-	 * @covers \Stogon\UnleashBundle\Event\UnleashContextEvent::getPayload
-	 */
 	public function testIsFeatureEnabledWithoutDefaultValueWithAuthenticated(): void
 	{
 		$featureName = 'random_feature';
@@ -253,10 +228,6 @@ class UnleashTest extends TestCase
 		$this->assertTrue($unleash->isFeatureEnabled($featureName));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::isFeatureEnabled
-	 */
 	public function testIsFeatureEnabledWithDiabledFeature(): void
 	{
 		$featureName = 'random_feature';


### PR DESCRIPTION
### :warning: Breaking changes

- drop support for PHP 7.4 and 8.0 versions since [they are not supported anymore](https://www.php.net/supported-versions.php) and bump minimum PHP version to 8.1
- drop support for Symfony 5.x and Twig 2.x
- change order of execution for fetching current user ID from context, it now try to use `UserInterface::getUserIdentifier` and then fallback to `getId` method (if it exists on given object), impacted strategies are :
  - `FlexibleRolloutStrategy`
  - `GradualRolloutUserIdStrategy`
  - `UserWithIdStrategy` => ⚠️ it now fallback to `$request->getUser()` if the `$user` object is not an object, does not implement a `getId` method or the user id is not found in strategy allowed IDs

### Changes

- Update php workflow actions versions
- remove legacy `lastguest/murmurhash` dependency
- add `rector/rector` dev dependency
- bump minimum supported version of Symfony 7 to `^7.4`
- upgrade to PHPUnit `^10.5`

### Fixes

- Resolved #17